### PR TITLE
WIP: Improve artifacts download

### DIFF
--- a/trino-rest-github/pom.xml
+++ b/trino-rest-github/pom.xml
@@ -101,6 +101,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>1.14</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-common</artifactId>
             <version>1.5.10</version>

--- a/trino-rest-github/pom.xml
+++ b/trino-rest-github/pom.xml
@@ -52,6 +52,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.12.3</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
             <version>2.12.3</version>
@@ -104,6 +110,12 @@
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
             <version>1.14</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core-asl</artifactId>
+            <version>4.4.1</version>
         </dependency>
 
         <dependency>

--- a/trino-rest-github/src/main/java/pl/net/was/rest/github/GithubPlugin.java
+++ b/trino-rest-github/src/main/java/pl/net/was/rest/github/GithubPlugin.java
@@ -37,6 +37,7 @@ import pl.net.was.rest.github.function.Steps;
 import pl.net.was.rest.github.function.UserGetter;
 import pl.net.was.rest.github.function.UserRepos;
 import pl.net.was.rest.github.function.Users;
+import pl.net.was.rest.github.function.Xml;
 
 import java.util.Set;
 
@@ -74,6 +75,7 @@ public class GithubPlugin
                 .add(Runs.class)
                 .add(Steps.class)
                 .add(Artifacts.class)
+                .add(Xml.class)
                 .build();
     }
 }

--- a/trino-rest-github/src/main/java/pl/net/was/rest/github/GithubRest.java
+++ b/trino-rest-github/src/main/java/pl/net/was/rest/github/GithubRest.java
@@ -89,6 +89,7 @@ import java.util.stream.Stream;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
@@ -349,6 +350,8 @@ public class GithubRest
                     new ColumnMetadata("filename", VARCHAR),
                     new ColumnMetadata("path", VARCHAR),
                     new ColumnMetadata("mimetype", VARCHAR),
+                    new ColumnMetadata("file_size_in_bytes", BIGINT),
+                    new ColumnMetadata("part_number", INTEGER),
                     new ColumnMetadata("contents", VARBINARY)))
             .build();
 
@@ -621,6 +624,8 @@ public class GithubRest
             "filename varchar, " +
             "path varchar, " +
             "mimetype varchar, " +
+            "file_size_in_bytes bigint, " +
+            "part_number int, " +
             "contents varbinary" +
             "))";
 

--- a/trino-rest-github/src/main/java/pl/net/was/rest/github/GithubRest.java
+++ b/trino-rest-github/src/main/java/pl/net/was/rest/github/GithubRest.java
@@ -56,6 +56,8 @@ import pl.net.was.rest.github.filter.RunFilter;
 import pl.net.was.rest.github.filter.StepFilter;
 import pl.net.was.rest.github.filter.UserFilter;
 import pl.net.was.rest.github.function.BaseFunction;
+import pl.net.was.rest.github.model.Artifact;
+import pl.net.was.rest.github.model.ArtifactsList;
 import pl.net.was.rest.github.model.Envelope;
 import pl.net.was.rest.github.model.Job;
 import pl.net.was.rest.github.model.JobsList;
@@ -82,11 +84,14 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
-import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -96,6 +101,7 @@ import static pl.net.was.rest.github.function.Artifacts.download;
 public class GithubRest
         implements Rest
 {
+    Logger log = Logger.getLogger(GithubRest.class.getName());
     public static final String SCHEMA_NAME = "default";
 
     private static String token;
@@ -103,15 +109,15 @@ public class GithubRest
 
     public static final Map<String, List<ColumnMetadata>> columns = new ImmutableMap.Builder<String, List<ColumnMetadata>>()
             .put("orgs", ImmutableList.of(
-                    new ColumnMetadata("login", createUnboundedVarcharType()),
+                    new ColumnMetadata("login", VARCHAR),
                     new ColumnMetadata("id", BIGINT),
-                    new ColumnMetadata("description", createUnboundedVarcharType()),
-                    new ColumnMetadata("name", createUnboundedVarcharType()),
-                    new ColumnMetadata("company", createUnboundedVarcharType()),
-                    new ColumnMetadata("blog", createUnboundedVarcharType()),
-                    new ColumnMetadata("location", createUnboundedVarcharType()),
-                    new ColumnMetadata("email", createUnboundedVarcharType()),
-                    new ColumnMetadata("twitter_username", createUnboundedVarcharType()),
+                    new ColumnMetadata("description", VARCHAR),
+                    new ColumnMetadata("name", VARCHAR),
+                    new ColumnMetadata("company", VARCHAR),
+                    new ColumnMetadata("blog", VARCHAR),
+                    new ColumnMetadata("location", VARCHAR),
+                    new ColumnMetadata("email", VARCHAR),
+                    new ColumnMetadata("twitter_username", VARCHAR),
                     new ColumnMetadata("is_verified", BOOLEAN),
                     new ColumnMetadata("has_organization_projects", BOOLEAN),
                     new ColumnMetadata("has_repository_projects", BOOLEAN),
@@ -121,36 +127,36 @@ public class GithubRest
                     new ColumnMetadata("following", BIGINT),
                     new ColumnMetadata("created_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
                     new ColumnMetadata("updated_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
-                    new ColumnMetadata("type", createUnboundedVarcharType()),
+                    new ColumnMetadata("type", VARCHAR),
                     new ColumnMetadata("total_private_repos", BIGINT),
                     new ColumnMetadata("owned_private_repos", BIGINT),
                     new ColumnMetadata("private_gists", BIGINT),
                     new ColumnMetadata("disk_usage", BIGINT),
                     new ColumnMetadata("collaborators", BIGINT),
-                    new ColumnMetadata("billing_email", createUnboundedVarcharType()),
-                    new ColumnMetadata("default_repository_permission", createUnboundedVarcharType()),
+                    new ColumnMetadata("billing_email", VARCHAR),
+                    new ColumnMetadata("default_repository_permission", VARCHAR),
                     new ColumnMetadata("members_can_create_repositories", BOOLEAN),
                     new ColumnMetadata("two_factor_requirement_enabled", BOOLEAN),
-                    new ColumnMetadata("members_allowed_repository_creation_type", createUnboundedVarcharType()),
+                    new ColumnMetadata("members_allowed_repository_creation_type", VARCHAR),
                     new ColumnMetadata("members_can_create_public_repositories", BOOLEAN),
                     new ColumnMetadata("members_can_create_private_repositories", BOOLEAN),
                     new ColumnMetadata("members_can_create_internal_repositories", BOOLEAN),
                     new ColumnMetadata("members_can_create_pages", BOOLEAN)))
             .put("users", ImmutableList.of(
-                    new ColumnMetadata("login", createUnboundedVarcharType()),
+                    new ColumnMetadata("login", VARCHAR),
                     new ColumnMetadata("id", BIGINT),
-                    new ColumnMetadata("avatar_url", createUnboundedVarcharType()),
-                    new ColumnMetadata("gravatar_id", createUnboundedVarcharType()),
-                    new ColumnMetadata("type", createUnboundedVarcharType()),
+                    new ColumnMetadata("avatar_url", VARCHAR),
+                    new ColumnMetadata("gravatar_id", VARCHAR),
+                    new ColumnMetadata("type", VARCHAR),
                     new ColumnMetadata("site_admin", BOOLEAN),
-                    new ColumnMetadata("name", createUnboundedVarcharType()),
-                    new ColumnMetadata("company", createUnboundedVarcharType()),
-                    new ColumnMetadata("blog", createUnboundedVarcharType()),
-                    new ColumnMetadata("location", createUnboundedVarcharType()),
-                    new ColumnMetadata("email", createUnboundedVarcharType()),
+                    new ColumnMetadata("name", VARCHAR),
+                    new ColumnMetadata("company", VARCHAR),
+                    new ColumnMetadata("blog", VARCHAR),
+                    new ColumnMetadata("location", VARCHAR),
+                    new ColumnMetadata("email", VARCHAR),
                     new ColumnMetadata("hireable", BOOLEAN),
-                    new ColumnMetadata("bio", createUnboundedVarcharType()),
-                    new ColumnMetadata("twitter_username", createUnboundedVarcharType()),
+                    new ColumnMetadata("bio", VARCHAR),
+                    new ColumnMetadata("twitter_username", VARCHAR),
                     new ColumnMetadata("public_repos", BIGINT),
                     new ColumnMetadata("public_gists", BIGINT),
                     new ColumnMetadata("followers", BIGINT),
@@ -159,188 +165,191 @@ public class GithubRest
                     new ColumnMetadata("updated_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3))))
             .put("repos", ImmutableList.of(
                     new ColumnMetadata("id", BIGINT),
-                    new ColumnMetadata("name", createUnboundedVarcharType()),
-                    new ColumnMetadata("full_name", createUnboundedVarcharType()),
+                    new ColumnMetadata("name", VARCHAR),
+                    new ColumnMetadata("full_name", VARCHAR),
                     new ColumnMetadata("owner_id", BIGINT),
-                    new ColumnMetadata("owner_login", createUnboundedVarcharType()),
+                    new ColumnMetadata("owner_login", VARCHAR),
                     new ColumnMetadata("private", BOOLEAN),
-                    new ColumnMetadata("description", createUnboundedVarcharType()),
+                    new ColumnMetadata("description", VARCHAR),
                     new ColumnMetadata("fork", BOOLEAN),
-                    new ColumnMetadata("url", createUnboundedVarcharType())))
+                    new ColumnMetadata("url", VARCHAR)))
             .put("pulls", ImmutableList.of(
-                    new ColumnMetadata("owner", createUnboundedVarcharType()),
-                    new ColumnMetadata("repo", createUnboundedVarcharType()),
+                    new ColumnMetadata("owner", VARCHAR),
+                    new ColumnMetadata("repo", VARCHAR),
                     new ColumnMetadata("id", BIGINT),
                     new ColumnMetadata("number", BIGINT),
-                    new ColumnMetadata("state", createUnboundedVarcharType()),
+                    new ColumnMetadata("state", VARCHAR),
                     new ColumnMetadata("locked", BOOLEAN),
-                    new ColumnMetadata("title", createUnboundedVarcharType()),
+                    new ColumnMetadata("title", VARCHAR),
                     new ColumnMetadata("user_id", BIGINT),
-                    new ColumnMetadata("user_login", createUnboundedVarcharType()),
-                    new ColumnMetadata("body", createUnboundedVarcharType()),
+                    new ColumnMetadata("user_login", VARCHAR),
+                    new ColumnMetadata("body", VARCHAR),
                     new ColumnMetadata("label_ids", new ArrayType(BIGINT)),
-                    new ColumnMetadata("label_names", new ArrayType(createUnboundedVarcharType())),
+                    new ColumnMetadata("label_names", new ArrayType(VARCHAR)),
                     new ColumnMetadata("milestone_id", BIGINT),
-                    new ColumnMetadata("milestone_title", createUnboundedVarcharType()),
-                    new ColumnMetadata("active_lock_reason", createUnboundedVarcharType()),
+                    new ColumnMetadata("milestone_title", VARCHAR),
+                    new ColumnMetadata("active_lock_reason", VARCHAR),
                     new ColumnMetadata("created_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
                     new ColumnMetadata("updated_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
                     new ColumnMetadata("closed_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
                     new ColumnMetadata("merged_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
-                    new ColumnMetadata("merge_commit_sha", createUnboundedVarcharType()),
+                    new ColumnMetadata("merge_commit_sha", VARCHAR),
                     new ColumnMetadata("assignee_id", BIGINT),
-                    new ColumnMetadata("assignee_login", createUnboundedVarcharType()),
+                    new ColumnMetadata("assignee_login", VARCHAR),
                     new ColumnMetadata("requested_reviewer_ids", new ArrayType(BIGINT)),
-                    new ColumnMetadata("requested_reviewer_logins", new ArrayType(createUnboundedVarcharType())),
-                    new ColumnMetadata("head_ref", createUnboundedVarcharType()),
-                    new ColumnMetadata("head_sha", createUnboundedVarcharType()),
-                    new ColumnMetadata("base_ref", createUnboundedVarcharType()),
-                    new ColumnMetadata("base_sha", createUnboundedVarcharType()),
-                    new ColumnMetadata("author_association", createUnboundedVarcharType()),
+                    new ColumnMetadata("requested_reviewer_logins", new ArrayType(VARCHAR)),
+                    new ColumnMetadata("head_ref", VARCHAR),
+                    new ColumnMetadata("head_sha", VARCHAR),
+                    new ColumnMetadata("base_ref", VARCHAR),
+                    new ColumnMetadata("base_sha", VARCHAR),
+                    new ColumnMetadata("author_association", VARCHAR),
                     new ColumnMetadata("draft", BOOLEAN)))
             .put("pull_commits", ImmutableList.of(
-                    new ColumnMetadata("owner", createUnboundedVarcharType()),
-                    new ColumnMetadata("repo", createUnboundedVarcharType()),
-                    new ColumnMetadata("sha", createUnboundedVarcharType()),
+                    new ColumnMetadata("owner", VARCHAR),
+                    new ColumnMetadata("repo", VARCHAR),
+                    new ColumnMetadata("sha", VARCHAR),
                     // this column is filled in from request params, it is not returned by the api
                     new ColumnMetadata("pull_number", BIGINT),
-                    new ColumnMetadata("commit_message", createUnboundedVarcharType()),
-                    new ColumnMetadata("commit_tree_sha", createUnboundedVarcharType()),
+                    new ColumnMetadata("commit_message", VARCHAR),
+                    new ColumnMetadata("commit_tree_sha", VARCHAR),
                     new ColumnMetadata("commit_comments_count", BIGINT),
                     new ColumnMetadata("commit_verified", BOOLEAN),
-                    new ColumnMetadata("commit_verification_reason", createUnboundedVarcharType()),
-                    new ColumnMetadata("author_name", createUnboundedVarcharType()),
-                    new ColumnMetadata("author_email", createUnboundedVarcharType()),
+                    new ColumnMetadata("commit_verification_reason", VARCHAR),
+                    new ColumnMetadata("author_name", VARCHAR),
+                    new ColumnMetadata("author_email", VARCHAR),
                     new ColumnMetadata("author_date", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
                     new ColumnMetadata("author_id", BIGINT),
-                    new ColumnMetadata("author_login", createUnboundedVarcharType()),
-                    new ColumnMetadata("committer_name", createUnboundedVarcharType()),
-                    new ColumnMetadata("committer_email", createUnboundedVarcharType()),
+                    new ColumnMetadata("author_login", VARCHAR),
+                    new ColumnMetadata("committer_name", VARCHAR),
+                    new ColumnMetadata("committer_email", VARCHAR),
                     new ColumnMetadata("committer_date", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
                     new ColumnMetadata("committer_id", BIGINT),
-                    new ColumnMetadata("committer_login", createUnboundedVarcharType()),
-                    new ColumnMetadata("parent_shas", new ArrayType(createUnboundedVarcharType()))))
+                    new ColumnMetadata("committer_login", VARCHAR),
+                    new ColumnMetadata("parent_shas", new ArrayType(VARCHAR))))
             .put("reviews", ImmutableList.of(
-                    new ColumnMetadata("owner", createUnboundedVarcharType()),
-                    new ColumnMetadata("repo", createUnboundedVarcharType()),
+                    new ColumnMetadata("owner", VARCHAR),
+                    new ColumnMetadata("repo", VARCHAR),
                     new ColumnMetadata("id", BIGINT),
                     // this column is filled in from request params, it is not returned by the api
                     new ColumnMetadata("pull_number", BIGINT),
                     new ColumnMetadata("user_id", BIGINT),
-                    new ColumnMetadata("user_login", createUnboundedVarcharType()),
-                    new ColumnMetadata("body", createUnboundedVarcharType()),
-                    new ColumnMetadata("state", createUnboundedVarcharType()),
+                    new ColumnMetadata("user_login", VARCHAR),
+                    new ColumnMetadata("body", VARCHAR),
+                    new ColumnMetadata("state", VARCHAR),
                     new ColumnMetadata("submitted_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
-                    new ColumnMetadata("commit_id", createUnboundedVarcharType()),
-                    new ColumnMetadata("author_association", createUnboundedVarcharType())))
+                    new ColumnMetadata("commit_id", VARCHAR),
+                    new ColumnMetadata("author_association", VARCHAR)))
             .put("review_comments", ImmutableList.of(
-                    new ColumnMetadata("owner", createUnboundedVarcharType()),
-                    new ColumnMetadata("repo", createUnboundedVarcharType()),
+                    new ColumnMetadata("owner", VARCHAR),
+                    new ColumnMetadata("repo", VARCHAR),
                     new ColumnMetadata("pull_request_review_id", BIGINT),
                     new ColumnMetadata("id", BIGINT),
-                    new ColumnMetadata("diff_hunk", createUnboundedVarcharType()),
-                    new ColumnMetadata("path", createUnboundedVarcharType()),
+                    new ColumnMetadata("diff_hunk", VARCHAR),
+                    new ColumnMetadata("path", VARCHAR),
                     new ColumnMetadata("position", BIGINT),
                     new ColumnMetadata("original_position", BIGINT),
-                    new ColumnMetadata("commit_id", createUnboundedVarcharType()),
-                    new ColumnMetadata("original_commit_id", createUnboundedVarcharType()),
+                    new ColumnMetadata("commit_id", VARCHAR),
+                    new ColumnMetadata("original_commit_id", VARCHAR),
                     new ColumnMetadata("in_reply_to_id", BIGINT),
                     new ColumnMetadata("user_id", BIGINT),
-                    new ColumnMetadata("user_login", createUnboundedVarcharType()),
-                    new ColumnMetadata("body", createUnboundedVarcharType()),
+                    new ColumnMetadata("user_login", VARCHAR),
+                    new ColumnMetadata("body", VARCHAR),
                     new ColumnMetadata("created_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
                     new ColumnMetadata("updated_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
-                    new ColumnMetadata("author_association", createUnboundedVarcharType()),
+                    new ColumnMetadata("author_association", VARCHAR),
                     new ColumnMetadata("start_line", BIGINT),
                     new ColumnMetadata("original_start_line", BIGINT),
-                    new ColumnMetadata("start_side", createUnboundedVarcharType()),
+                    new ColumnMetadata("start_side", VARCHAR),
                     new ColumnMetadata("line", BIGINT),
                     new ColumnMetadata("original_line", BIGINT),
-                    new ColumnMetadata("side", createUnboundedVarcharType())))
+                    new ColumnMetadata("side", VARCHAR)))
             .put("issues", ImmutableList.of(
-                    new ColumnMetadata("owner", createUnboundedVarcharType()),
-                    new ColumnMetadata("repo", createUnboundedVarcharType()),
+                    new ColumnMetadata("owner", VARCHAR),
+                    new ColumnMetadata("repo", VARCHAR),
                     new ColumnMetadata("id", BIGINT),
                     new ColumnMetadata("number", BIGINT),
-                    new ColumnMetadata("state", createUnboundedVarcharType()),
-                    new ColumnMetadata("title", createUnboundedVarcharType()),
-                    new ColumnMetadata("body", createUnboundedVarcharType()),
+                    new ColumnMetadata("state", VARCHAR),
+                    new ColumnMetadata("title", VARCHAR),
+                    new ColumnMetadata("body", VARCHAR),
                     new ColumnMetadata("user_id", BIGINT),
-                    new ColumnMetadata("user_login", createUnboundedVarcharType()),
+                    new ColumnMetadata("user_login", VARCHAR),
                     new ColumnMetadata("label_ids", new ArrayType(BIGINT)),
-                    new ColumnMetadata("label_names", new ArrayType(createUnboundedVarcharType())),
+                    new ColumnMetadata("label_names", new ArrayType(VARCHAR)),
                     new ColumnMetadata("assignee_id", BIGINT),
-                    new ColumnMetadata("assignee_login", createUnboundedVarcharType()),
+                    new ColumnMetadata("assignee_login", VARCHAR),
                     new ColumnMetadata("milestone_id", BIGINT),
-                    new ColumnMetadata("milestone_title", createUnboundedVarcharType()),
+                    new ColumnMetadata("milestone_title", VARCHAR),
                     new ColumnMetadata("locked", BOOLEAN),
-                    new ColumnMetadata("active_lock_reason", createUnboundedVarcharType()),
+                    new ColumnMetadata("active_lock_reason", VARCHAR),
                     new ColumnMetadata("comments", BIGINT),
                     new ColumnMetadata("closed_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
                     new ColumnMetadata("created_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
                     new ColumnMetadata("updated_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
-                    new ColumnMetadata("author_association", createUnboundedVarcharType())))
+                    new ColumnMetadata("author_association", VARCHAR)))
             .put("issue_comments", ImmutableList.of(
-                    new ColumnMetadata("owner", createUnboundedVarcharType()),
-                    new ColumnMetadata("repo", createUnboundedVarcharType()),
+                    new ColumnMetadata("owner", VARCHAR),
+                    new ColumnMetadata("repo", VARCHAR),
                     new ColumnMetadata("id", BIGINT),
-                    new ColumnMetadata("body", createUnboundedVarcharType()),
+                    new ColumnMetadata("body", VARCHAR),
                     new ColumnMetadata("user_id", BIGINT),
-                    new ColumnMetadata("user_login", createUnboundedVarcharType()),
+                    new ColumnMetadata("user_login", VARCHAR),
                     new ColumnMetadata("created_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
                     new ColumnMetadata("updated_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
-                    new ColumnMetadata("author_association", createUnboundedVarcharType())))
+                    new ColumnMetadata("author_association", VARCHAR)))
             .put("runs", ImmutableList.of(
-                    new ColumnMetadata("owner", createUnboundedVarcharType()),
-                    new ColumnMetadata("repo", createUnboundedVarcharType()),
+                    new ColumnMetadata("owner", VARCHAR),
+                    new ColumnMetadata("repo", VARCHAR),
                     new ColumnMetadata("id", BIGINT),
-                    new ColumnMetadata("name", createUnboundedVarcharType()),
-                    new ColumnMetadata("node_id", createUnboundedVarcharType()),
-                    new ColumnMetadata("head_branch", createUnboundedVarcharType()),
-                    new ColumnMetadata("head_sha", createUnboundedVarcharType()),
+                    new ColumnMetadata("name", VARCHAR),
+                    new ColumnMetadata("node_id", VARCHAR),
+                    new ColumnMetadata("head_branch", VARCHAR),
+                    new ColumnMetadata("head_sha", VARCHAR),
                     new ColumnMetadata("run_number", BIGINT),
-                    new ColumnMetadata("event", createUnboundedVarcharType()),
-                    new ColumnMetadata("status", createUnboundedVarcharType()),
-                    new ColumnMetadata("conclusion", createUnboundedVarcharType()),
+                    new ColumnMetadata("event", VARCHAR),
+                    new ColumnMetadata("status", VARCHAR),
+                    new ColumnMetadata("conclusion", VARCHAR),
                     new ColumnMetadata("workflow_id", BIGINT),
                     new ColumnMetadata("created_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
                     new ColumnMetadata("updated_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3))))
             .put("jobs", ImmutableList.of(
-                    new ColumnMetadata("owner", createUnboundedVarcharType()),
-                    new ColumnMetadata("repo", createUnboundedVarcharType()),
+                    new ColumnMetadata("owner", VARCHAR),
+                    new ColumnMetadata("repo", VARCHAR),
                     new ColumnMetadata("id", BIGINT),
                     new ColumnMetadata("run_id", BIGINT),
-                    new ColumnMetadata("node_id", createUnboundedVarcharType()),
-                    new ColumnMetadata("head_sha", createUnboundedVarcharType()),
-                    new ColumnMetadata("status", createUnboundedVarcharType()),
-                    new ColumnMetadata("conclusion", createUnboundedVarcharType()),
+                    new ColumnMetadata("node_id", VARCHAR),
+                    new ColumnMetadata("head_sha", VARCHAR),
+                    new ColumnMetadata("status", VARCHAR),
+                    new ColumnMetadata("conclusion", VARCHAR),
                     new ColumnMetadata("started_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
                     new ColumnMetadata("completed_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
-                    new ColumnMetadata("name", createUnboundedVarcharType())))
+                    new ColumnMetadata("name", VARCHAR)))
             .put("steps", ImmutableList.of(
-                    new ColumnMetadata("owner", createUnboundedVarcharType()),
-                    new ColumnMetadata("repo", createUnboundedVarcharType()),
+                    new ColumnMetadata("owner", VARCHAR),
+                    new ColumnMetadata("repo", VARCHAR),
                     new ColumnMetadata("job_id", BIGINT),
-                    new ColumnMetadata("name", createUnboundedVarcharType()),
-                    new ColumnMetadata("status", createUnboundedVarcharType()),
-                    new ColumnMetadata("conclusion", createUnboundedVarcharType()),
+                    new ColumnMetadata("name", VARCHAR),
+                    new ColumnMetadata("status", VARCHAR),
+                    new ColumnMetadata("conclusion", VARCHAR),
                     new ColumnMetadata("number", BIGINT),
                     new ColumnMetadata("started_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
                     new ColumnMetadata("completed_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3))))
             .put("artifacts", ImmutableList.of(
-                    new ColumnMetadata("owner", createUnboundedVarcharType()),
-                    new ColumnMetadata("repo", createUnboundedVarcharType()),
+                    new ColumnMetadata("owner", VARCHAR),
+                    new ColumnMetadata("repo", VARCHAR),
                     new ColumnMetadata("run_id", BIGINT),
                     new ColumnMetadata("id", BIGINT),
                     new ColumnMetadata("size_in_bytes", BIGINT),
-                    new ColumnMetadata("name", createUnboundedVarcharType()),
-                    new ColumnMetadata("url", createUnboundedVarcharType()),
-                    new ColumnMetadata("archive_download_url", createUnboundedVarcharType()),
+                    new ColumnMetadata("name", VARCHAR),
+                    new ColumnMetadata("url", VARCHAR),
+                    new ColumnMetadata("archive_download_url", VARCHAR),
                     new ColumnMetadata("expired", BOOLEAN),
                     new ColumnMetadata("created_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
                     new ColumnMetadata("expires_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
                     new ColumnMetadata("updated_at", TimestampWithTimeZoneType.createTimestampWithTimeZoneType(3)),
-                    new ColumnMetadata("contents", createUnboundedVarcharType())))
+                    new ColumnMetadata("filename", VARCHAR),
+                    new ColumnMetadata("path", VARCHAR),
+                    new ColumnMetadata("mimetype", VARCHAR),
+                    new ColumnMetadata("contents", VARBINARY)))
             .build();
 
     // TODO add tests that would verify this using getSqlType(), print the expected string so its easy to copy&paste
@@ -609,7 +618,10 @@ public class GithubRest
             "created_at timestamp(3) with time zone, " +
             "expires_at timestamp(3) with time zone, " +
             "updated_at timestamp(3) with time zone, " +
-            "contents varchar" +
+            "filename varchar, " +
+            "path varchar, " +
+            "mimetype varchar, " +
+            "contents varbinary" +
             "))";
 
     private final Map<String, Map<String, ColumnHandle>> columnHandles;
@@ -940,7 +952,7 @@ public class GithubRest
                 item -> {
                     item.setOwner(owner);
                     item.setRepo(repo);
-                    return item.toRow();
+                    return Stream.of(item.toRow());
                 });
     }
 
@@ -959,7 +971,7 @@ public class GithubRest
                 item -> {
                     item.setOwner(owner);
                     item.setRepo(repo);
-                    return item.toRow();
+                    return Stream.of(item.toRow());
                 });
     }
 
@@ -1014,20 +1026,35 @@ public class GithubRest
 
         String owner = (String) filter.getFilter((RestColumnHandle) columns.get("owner"), constraint);
         String repo = (String) filter.getFilter((RestColumnHandle) columns.get("repo"), constraint);
+        Long runId = (Long) filter.getFilter((RestColumnHandle) columns.get("run_id"), constraint);
+
+        IntFunction<Call<ArtifactsList>> fetcher = page -> service.listArtifacts("Bearer " + token, owner, repo, 100, page);
+        if (runId != null) {
+            fetcher = page -> service.listRunArtifacts("Bearer " + token, owner, repo, runId, 100, page);
+        }
+        else {
+            log.warning(format("Missing filter on run_id, will try to fetch all artifacts for %s/%s", owner, repo));
+        }
         // TODO this needs to allow pushing down multiple run_id values and make a separate request for each
         return getRowsFromPagesEnvelope(
-                page -> service.listArtifacts("Bearer " + token, owner, repo, 100, page),
+                fetcher,
                 item -> {
+                    Stream.Builder<List<?>> result = Stream.builder();
                     item.setOwner(owner);
                     item.setRepo(repo);
+                    if (runId != null) {
+                        item.setRunId(runId);
+                    }
                     try {
-                        item.setContents(download(service, token, owner, repo, item.getId()));
+                        for (Artifact artifact : download(service, token, item)) {
+                            result.add(artifact.toRow());
+                        }
                     }
                     catch (IOException e) {
                         // TODO how to better handle this?
                         e.printStackTrace();
                     }
-                    return item.toRow();
+                    return result.build();
                 });
     }
 
@@ -1076,11 +1103,12 @@ public class GithubRest
     }
 
     // TODO this abomination is even worse
-    private <T, E extends Envelope<T>> Collection<? extends List<?>> getRowsFromPagesEnvelope(IntFunction<Call<E>> fetcher, Function<T, List<?>> mapper)
+    private <T, E extends Envelope<T>> Collection<? extends List<?>> getRowsFromPagesEnvelope(IntFunction<Call<E>> fetcher, Function<T, Stream<List<?>>> mapper)
     {
         ImmutableList.Builder<List<?>> result = new ImmutableList.Builder<>();
 
         int page = 1;
+        int total = 0;
         while (true) {
             Response<E> response;
             try {
@@ -1093,11 +1121,16 @@ public class GithubRest
                 break;
             }
             checkServiceResponse(response);
-            List<T> items = requireNonNull(response.body()).getItems();
+            E envelope = requireNonNull(response.body());
+            List<T> items = envelope.getItems();
             if (items.size() == 0) {
                 break;
             }
-            result.addAll(items.stream().map(mapper).collect(toList()));
+            result.addAll(items.stream().flatMap(mapper).collect(toList()));
+            total += items.size();
+            if (total >= envelope.getTotalCount()) {
+                break;
+            }
         }
 
         return result.build();

--- a/trino-rest-github/src/main/java/pl/net/was/rest/github/Sync.java
+++ b/trino-rest-github/src/main/java/pl/net/was/rest/github/Sync.java
@@ -627,7 +627,7 @@ public class Sync
             conn.createStatement().executeUpdate(
                     "CREATE TABLE IF NOT EXISTS " + destSchema + ".artifacts AS SELECT * FROM " + srcSchema + ".artifacts WITH NO DATA");
             // consider adding some indexes:
-            // ALTER TABLE artifacts ADD PRIMARY KEY (id);
+            // ALTER TABLE artifacts ADD PRIMARY KEY (id, path, part_number);
             // CREATE INDEX ON artifacts(owner, repo);
             // CREATE INDEX ON artifacts(run_id);
 
@@ -644,7 +644,7 @@ public class Sync
             String query = "INSERT INTO " + destSchema + ".artifacts " +
                     "SELECT src.* " +
                     "FROM artifacts src " +
-                    "LEFT JOIN " + destSchema + ".artifacts dst ON (dst.run_id, dst.id, dst.path) = (src.run_id, src.id, src.path) " +
+                    "LEFT JOIN " + destSchema + ".artifacts dst ON (dst.id, dst.path, dst.part_number) = (src.id, src.path, src.part_number) " +
                     "WHERE src.owner = ? AND src.repo = ? AND src.run_id = ? AND dst.id IS NULL";
             PreparedStatement insertStatement = conn.prepareStatement(query);
             insertStatement.setString(1, options.owner);

--- a/trino-rest-github/src/main/java/pl/net/was/rest/github/filter/StepFilter.java
+++ b/trino-rest-github/src/main/java/pl/net/was/rest/github/filter/StepFilter.java
@@ -26,6 +26,6 @@ public class StepFilter
         return ImmutableMap.of(
                 "owner", FilterType.EQUAL,
                 "repo", FilterType.EQUAL,
-                "run_id", FilterType.EQUAL);
+                "job_id", FilterType.EQUAL);
     }
 }

--- a/trino-rest-github/src/main/java/pl/net/was/rest/github/function/Xml.java
+++ b/trino-rest-github/src/main/java/pl/net/was/rest/github/function/Xml.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.net.was.rest.github.function;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+
+import java.io.IOException;
+
+import static io.trino.spi.type.StandardTypes.VARCHAR;
+
+@ScalarFunction("xml2json")
+@Description("Convert XML to JSON")
+public class Xml
+{
+    @SqlType(VARCHAR)
+    public Slice xml2json(@SqlType(VARCHAR) Slice xml)
+            throws IOException
+    {
+        XmlMapper xmlMapper = new XmlMapper();
+        JsonNode node = xmlMapper.readTree(xml.getBytes());
+
+        ObjectMapper jsonMapper = new ObjectMapper();
+        String json = jsonMapper.writeValueAsString(node);
+        return Slices.utf8Slice(json);
+    }
+}

--- a/trino-rest-github/src/main/java/pl/net/was/rest/github/model/Artifact.java
+++ b/trino-rest-github/src/main/java/pl/net/was/rest/github/model/Artifact.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.IntegerType.INTEGER;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Artifact
@@ -46,6 +47,8 @@ public class Artifact
     private String filename;
     private String path;
     private String mimetype;
+    private long fileSizeInBytes;
+    private int partNumber;
     private byte[] contents;
 
     public Artifact(
@@ -116,6 +119,16 @@ public class Artifact
         this.mimetype = mimetype;
     }
 
+    public void setPartNumber(int partNumber)
+    {
+        this.partNumber = partNumber;
+    }
+
+    public void setFileSizeInBytes(long fileSizeInBytes)
+    {
+        this.fileSizeInBytes = fileSizeInBytes;
+    }
+
     public void setContents(byte[] contents)
     {
         this.contents = contents;
@@ -139,6 +152,8 @@ public class Artifact
                 filename,
                 path,
                 mimetype,
+                fileSizeInBytes,
+                partNumber,
                 Slices.wrappedBuffer(contents != null ? contents : new byte[0]));
     }
 
@@ -161,6 +176,8 @@ public class Artifact
         writeString(rowBuilder, filename);
         writeString(rowBuilder, path);
         writeString(rowBuilder, mimetype);
+        BIGINT.writeLong(rowBuilder, fileSizeInBytes);
+        INTEGER.writeLong(rowBuilder, partNumber);
         writeBytes(rowBuilder, contents);
     }
 

--- a/trino-rest-github/src/main/java/pl/net/was/rest/github/model/BaseBlockWriter.java
+++ b/trino-rest-github/src/main/java/pl/net/was/rest/github/model/BaseBlockWriter.java
@@ -14,6 +14,7 @@
 
 package pl.net.was.rest.github.model;
 
+import io.airlift.slice.Slices;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.DateTimeEncoding;
 
@@ -23,6 +24,7 @@ import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_SECONDS;
 import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.Timestamps.roundDiv;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 
 abstract class BaseBlockWriter
@@ -47,6 +49,15 @@ abstract class BaseBlockWriter
             return;
         }
         VARCHAR.writeString(rowBuilder, value);
+    }
+
+    protected static void writeBytes(BlockBuilder rowBuilder, byte[] value)
+    {
+        if (value == null) {
+            rowBuilder.appendNull();
+            return;
+        }
+        VARBINARY.writeSlice(rowBuilder, Slices.wrappedBuffer(value));
     }
 
     protected static void writeTimestamp(BlockBuilder rowBuilder, ZonedDateTime value)

--- a/trino-rest-github/src/main/java/pl/net/was/rest/github/model/Envelope.java
+++ b/trino-rest-github/src/main/java/pl/net/was/rest/github/model/Envelope.java
@@ -19,4 +19,6 @@ import java.util.List;
 public interface Envelope<T>
 {
     List<T> getItems();
+
+    long getTotalCount();
 }

--- a/trino-rest-github/src/test/java/pl/net/was/rest/github/TestGithubQueries.java
+++ b/trino-rest-github/src/test/java/pl/net/was/rest/github/TestGithubQueries.java
@@ -68,6 +68,7 @@ public class TestGithubQueries
         assertQueryFails("SELECT * FROM runs", "Missing required constraint for owner");
         assertQueryFails("SELECT * FROM jobs", "Missing required constraint for owner");
         assertQueryFails("SELECT * FROM steps", "Missing required constraint for owner");
+        assertQueryFails("SELECT * FROM artifacts", "Missing required constraint for owner");
     }
 
     @Test
@@ -89,6 +90,7 @@ public class TestGithubQueries
         assertQuerySucceeds("SELECT * FROM unnest(runs('nineinchnick', 'trino-rest', 1))");
         assertQuerySucceeds("SELECT * FROM unnest(jobs('nineinchnick', 'trino-rest', 1))");
         assertQuerySucceeds("SELECT * FROM unnest(steps('nineinchnick', 'trino-rest', 1))");
+        assertQuerySucceeds("SELECT * FROM unnest(artifacts('nineinchnick', 'trino-rest', 1))");
         // TODO figure out why this requires special permissions
         //assertQuerySucceeds("SELECT job_logs('nineinchnick', 'trino-rest', 1)");
         // TODO there are yet no artifacts in this repo


### PR DESCRIPTION
Fetch artifacts contents as separate rows.

With big files, this still hits the page size limits.
1. [x] See if fetching of metadata actually causes files to be truncated, create a copy of the stream if necessary.
2. [x] For now, truncate big files.
3. [x] Consider adding an option to either: ignore big files, truncate them, split them into chunks 